### PR TITLE
Firefox support for un-blurred previews

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -116,3 +116,15 @@ body {
   width: 100%;
   display: block;
 }
+
+/* image-rendering behaves differently on firefox than on other browsers
+ * this should bring it in line for now
+ * as browsers gradually change their implementation of this relatively new property,
+ * this file may need further maintenance to keep these previews unblurred
+ * or eventually this section may be removed if they get their algorithms in line
+ */
+@-moz-document url-prefix() {
+  .preview {
+    image-rendering: crisp-edges;
+  }
+}


### PR DESCRIPTION
As-written, preview images were un-interpolated (and therefore un-blurred) in Chrome, Edge, Safari mobile, and Chrome mobile, but broken in Internet Explorer and Firefox (these are the browsers I was able to test).

Image-rendering is a new property so the browsers don't all use the same algorithms for the same values.  IE doesn't support the property at all (therefore can't be fixed afaik), but Firefox does, and using "crisp-edges" makes it show the same behaviour that "pixelated" does on other browsers.